### PR TITLE
[CI] Added job running tests with compatibility layer enabled

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -26,7 +26,7 @@ jobs:
             TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     regression-experience-setup2:
-        name: "PHP 7.4/MySQL"
+        name: "PHP 7.4/MySQL/Compatibility layer"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
             project-edition: "experience"
@@ -35,6 +35,7 @@ jobs:
             test-setup-phase-1: "--profile=regression --suite=setup-experience --tags=~@part2 --mode=standard"
             test-setup-phase-2: "--profile=regression --suite=setup-experience --tags=@part2 --mode=standard"
             setup: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
+            use-compatibility-layer: true
             timeout: 90
         secrets:
             SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}


### PR DESCRIPTION
Requires https://github.com/ibexa/gh-workflows/pull/6

Runs one of the job with compatibility-later enabled

Test failures are not related, we need to work on test stability again