### PR TITLE
IBX-4741: Migration from TRAVIS_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -83,6 +83,13 @@ jobs:
       - name: Set Environment
         run: |
           echo "BUILD_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+          installation_id: ${{ secrets.AUTOMATION_CLIENT_INSTALLATION }}
+          private_key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
       - name: Get previous release tag based on type
         id: prevrelease
         uses: ibexa/version-logic-action@master
@@ -106,7 +113,7 @@ jobs:
       - name: Run generator in a loop
         id: generator
         env:
-          INPUT_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+          INPUT_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           INPUT_JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
         run: |
           cat > input.json <<'EOF'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | IBX-4741
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.x+`
| **BC breaks**                          | no
| **Doc needed**                       | yes (already done)

This will migrate from the old setup `generator` step in a release workflow.
For specifics see the wiki: https://ibexa.atlassian.net/wiki/spaces/ENG/pages/12713999/Migrating+from+TRAVIS+GITHUB+TOKEN

Merge up path: 4.3 -> master

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that the target branch is set correctly.
- [x] Asked for a review (already reviewed in https://github.com/ibexa/commerce/pull/200).
