### PR TITLE
Fixed getting previous release tag

### DIFF
--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get previous last full release
         id: prevfull
         run: |
-          OUT=$(hub api /repos/${{ github.repository }}/releases | jq -r -s '[ .[][].tag_name | select(. | contains("rc") or contains("beta") or contains("alpha") | not) ] | first')
+          OUT=$(hub api /repos/${{ github.repository }}/releases | jq -r '[.[] | select(.tag_name | test("^(?!.*alpha|.*beta|.*rc).*$")) | .tag_name] | sort_by(.) | last')
           echo "tag=$( echo "$OUT" )" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Alpha/Beta/RC specific:
During some external conditions, prevfull step could get the incorrect last full release tag, and thus changelog calculation was incorrect.

For example:
If we are releasing 4.5.0-beta1 and prevfull incorrectly returned 3.3.32 it would trigger a release comparison with the wrong tag (the proper one is 4.4.0, as per Ibexa rules).

Reviewed in: https://github.com/ibexa/commerce/pull/250