### PR TITLE
IBX-11797: [3.3] Bump Node to 20

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -23,7 +23,6 @@ jobs:
         name: "PHP 7.3/Node 20/PostgreSQL/Varnish/Redis/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
-            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=experience"
@@ -40,7 +39,6 @@ jobs:
         name: "PHP 7.4/Node 20/MySQL/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
-            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=experience"
@@ -57,7 +55,6 @@ jobs:
         name: "PHP 8.3/Node 20/MySQL/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
-            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=experience"
@@ -74,7 +71,6 @@ jobs:
         name: "Map\\Host matcher tests"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
-            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=browser --suite=page-builder"
@@ -86,7 +82,6 @@ jobs:
         name: "Map\\URI matcher tests"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
-            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=browser --suite=page-builder"
@@ -97,7 +92,6 @@ jobs:
         name: "URIElement matcher tests"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
-            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=browser --suite=page-builder"
@@ -108,7 +102,6 @@ jobs:
         name: "Compound matcher tests"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
-            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=browser --suite=page-builder"

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -20,9 +20,10 @@ on:
 
 jobs:
     regression-experience-setup1:
-        name: "PHP 7.3/Node 14/PostgreSQL/Varnish/Redis/Multirepository"
+        name: "PHP 7.3/Node 20/PostgreSQL/Varnish/Redis/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=experience"
@@ -32,13 +33,14 @@ jobs:
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             job-count: 4
             multirepository: true
-            php-image: "ghcr.io/ibexa/docker/php:7.3-node14"
+            php-image: "ghcr.io/ibexa/docker/php:7.3-node20"
             timeout: 120
         secrets: inherit
     regression-experience-setup2:
-        name: "PHP 7.4/Node 16/MySQL/Multirepository"
+        name: "PHP 7.4/Node 20/MySQL/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=experience"
@@ -48,13 +50,14 @@ jobs:
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             job-count: 4
             multirepository: true
-            php-image: "ghcr.io/ibexa/docker/php:7.4-node16"
+            php-image: "ghcr.io/ibexa/docker/php:7.4-node20"
             timeout: 120
         secrets: inherit
     regression-experience-setup3:
-        name: "PHP 8.3/Node 18/MySQL/Multirepository"
+        name: "PHP 8.3/Node 20/MySQL/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=experience"
@@ -64,13 +67,14 @@ jobs:
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             job-count: 4
             multirepository: true
-            php-image: "ghcr.io/ibexa/docker/php:8.3-node18"
+            php-image: "ghcr.io/ibexa/docker/php:8.3-node20"
             timeout: 120
         secrets: inherit
     page-builder-matchers-1:
         name: "Map\\Host matcher tests"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=browser --suite=page-builder"
@@ -82,6 +86,7 @@ jobs:
         name: "Map\\URI matcher tests"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=browser --suite=page-builder"
@@ -92,6 +97,7 @@ jobs:
         name: "URIElement matcher tests"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=browser --suite=page-builder"
@@ -102,6 +108,7 @@ jobs:
         name: "Compound matcher tests"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'ibx-11797-v3.3'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=browser --suite=page-builder"


### PR DESCRIPTION
| :ticket: Issue | IBX-11797 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/ci-scripts/pull/139
- https://github.com/ibexa/docker/pull/60


#### Description:
Increased Node version from 14, 16 & 18 to version 20.

Due to sass 1.100 requirement (`">=20.19.0"`).

On v4.6 Node version 18 will be increased to version 20.

#### For QA:
Tested ignoring unsolvable advisories.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
