### PR TITLE
IBX-11778: Updated deprecated GitHub Actions in auto_tag workflow

### DIFF
--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -125,13 +125,14 @@ jobs:
       - name: Commit, tag and push
         if: inputs.real_op
         env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           GIT_PUSH_ARGS: ${{ inputs.git_push_args }}
-          ROBOT_TOKEN: ${{ secrets.EZROBOT_PAT }}
+          VERSION: ${{ inputs.version }}
         run: |
-          git config --local user.email "681611+ezrobot@users.noreply.github.com"
-          git config --local user.name "ezrobot"
-          git remote set-url origin https://x-access-token:${{ env.ROBOT_TOKEN }}@github.com/${{ github.repository }}
+          gh auth setup-git
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add composer.*
-          git commit -m "[composer] Set dependencies for ${{ inputs.version }} release + .lock"
-          git tag "v${{ inputs.version }}"
-          git push origin "v${{ inputs.version }}" ${GIT_PUSH_ARGS}
+          git commit -m "[composer] Set dependencies for ${VERSION} release + .lock"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}" ${GIT_PUSH_ARGS}

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -21,118 +21,20 @@ jobs:
   # No need to wait for the parent package (ibexa/headless) — it is available on Packagist, not via Satis
   action:
     runs-on: ubuntu-26.04
-    
+
     steps:
-      - name: Install sponge
-        run: |
-          sudo apt-get install -y moreutils
-
-      - name: Setup PHP Action
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.3
-          coverage: none
-          extensions: pdo_sqlite, gd
-
-      - name: Generate token
-        id: generate_token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
-          private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
-          owner: ${{ github.repository_owner }}
-
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
-      - name: Get release information
-        id: release
-        shell: bash
-        run: |
-          response=$(gh api "/repos/ibexa/release-maker/contents/releases/${{ inputs.version }}/release.json")
-          {
-            echo 'data<<EOF'
-            echo "$response"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
-        env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-
-      # The effect of this jq command is to take a JSON array of objects,
-      # transform each object into a new object using its packageName and targetVersion properties,
-      # and return the result as a single JSON object.
-      # The sponge command is used to pipe the output of jq back into the same file, effectively replacing its contents with the updated JSON data.
-      - name: Process release information
-        run: |
-          cat > input.json <<'EOF'
-          ${{ steps.release.outputs.data }}
-          EOF
-          jq -r '.["content"]' input.json | base64 --decode | jq -c . > release.json
-          jq -s '[ .[][] | { (.packageName): (.targetVersion) } ] | add' release.json | sponge release.json
-
-      - name: Set minimum stability
-        run: |
-          VERSION=$( echo ${{ inputs.version }} | cut -d '-' -f 2 )
-          SET_STABILITY="composer config minimum-stability"
-          $SET_STABILITY --unset
-          composer config prefer-stable --unset
-          case $VERSION in
-            alpha*|beta*|rc*) composer config prefer-stable true ;;&
-            alpha*) $SET_STABILITY alpha ;;
-            beta*) $SET_STABILITY beta ;;
-            rc*) $SET_STABILITY rc ;;
-          esac;
-
-      - name: Patch parent version for Experience
-        run: jq '.require["ibexa/headless"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
-
-      # The effect of this jq command is to modify the require property of the input JSON object by using values from the $release object,
-      # if they exist, to update the values of the keys in the require object.
-      - name: Patch composer require versions
-        run: |
-          jq --slurpfile release <(cat release.json) '
-            .require |= (
-              to_entries | 
-              map({
-                key: .key,
-                value: (if ($release[0][.key]) then $release[0][.key] else .value end)
-              }) | from_entries
-            )
-          ' composer.json > composer.tmp
-          mv composer.tmp composer.json
-
-      - name: Reformat composer.json
-        run: cat composer.json | unexpand -t2 | expand -t4 | sponge composer.json
-
-      - name: Preview composer.json
-        run: cat composer.json
-
-      - name: Add composer keys for private packagist
-        run: |
-          composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
-          composer config github-oauth.github.com $APP_GITHUB_TOKEN
-        env:
-          SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
-          SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
-          APP_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-
-      - name: Composer update
-        run: |
-          composer update --no-scripts --no-plugins --no-install
-          composer validate
-
-      - name: Commit, tag and push
-        if: inputs.real_op
-        env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          GIT_PUSH_ARGS: ${{ inputs.git_push_args }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          gh auth setup-git
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add composer.*
-          git commit -m "[composer] Set dependencies for ${VERSION} release + .lock"
-          git tag "v${VERSION}"
-          git push origin "v${VERSION}" ${GIT_PUSH_ARGS}
+      - name: Set dependency versions, commit, tag and push
+        uses: ibexa/gh-workflows/actions/create-metapackage-tag@main
+        with:
+          version: ${{ inputs.version }}
+          pin-packages: ibexa/headless
+          real-op: ${{ inputs.real_op }}
+          git-push-args: ${{ inputs.git_push_args }}
+          gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+          gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+          satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
+          satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -18,50 +18,9 @@ on:
         required: false
 
 jobs:
-  preparation:
-    runs-on: ubuntu-latest
-    # This should allow parallel runs in a chain, e.g. OSS->Headless->Experience->Commerce
-    # whilst allowing Satis to process
-    timeout-minutes: 30
-
-    steps:
-      - name: Check for admin-ui-assets tag
-        if: github.event.repository.name == 'oss'
-        uses: octokit/request-action@v2.x
-        with:
-          owner: ibexa
-          repo: admin-ui-assets
-          route: /repos/{owner}/{repo}/contents/package.json?ref=v${{ inputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
-
-      # The jq command would return a zero exit status if it was able to filter the input JSON data and
-      # produce at least one matching object in the array, and a non-zero exit status if no matching object was found.
-      # This particular JQ filter expression:
-      # .packages."${{ env.PARENT }}"[]: accesses an array of objects in the packages object, with the key specified by the environment variable PARENT.
-      # select(.version == "${{ env.V_VERSION }}"): filters the array to only include objects where the version property is equal to the value of the environment variable V_VERSION.
-
-      # No need to validate for oss version in satis
-      # No need to validate for headless version in satis
-
-      - name: Validate satis for experience version
-        if: github.event.repository.name == 'commerce'
-        env:
-          SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
-          SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
-          PARENT: ibexa/experience
-          V_VERSION: v${{ inputs.version }}
-        run: |
-          for EXPONENTIAL_BACKOFF in {1..10}; do
-          curl https://updates.ibexa.co/p2/${PARENT}.json -s -u $SATIS_NETWORK_KEY:$SATIS_NETWORK_TOKEN | jq -e '.packages."${{ env.PARENT }}"[] | select(.version == "${{ env.V_VERSION }}")' && break;
-            DELAY=$((2**$EXPONENTIAL_BACKOFF))
-            echo "${PARENT}:${V_VERSION} not yet available, sleeping for $DELAY seconds"
-            sleep $DELAY
-          done
-  
+  # No need to wait for the parent package (ibexa/headless) — it is available on Packagist, not via Satis
   action:
-    needs: preparation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     
     steps:
       - name: Install sponge
@@ -74,27 +33,29 @@ jobs:
           php-version: 8.3
           coverage: none
           extensions: pdo_sqlite, gd
-          tools: cs2pr
 
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.AUTOMATION_CLIENT_ID }}
-          installation_id: ${{ secrets.AUTOMATION_CLIENT_INSTALLATION }}
-          private_key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+          client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+          private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+          owner: ${{ github.repository_owner }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Get release information
-        uses: octokit/request-action@v2.x
         id: release
-        with:
-          owner: ibexa
-          repo: release-maker
-          route: /repos/{owner}/{repo}/contents/releases/${{ inputs.version }}/release.json
+        shell: bash
+        run: |
+          response=$(gh api "/repos/ibexa/release-maker/contents/releases/${{ inputs.version }}/release.json")
+          {
+            echo 'data<<EOF'
+            echo "$response"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
@@ -123,18 +84,8 @@ jobs:
             rc*) $SET_STABILITY rc ;;
           esac;
 
-      - name: Patch parent version for OSS
-        if: github.event.repository.name == 'oss'
-        run: jq '.require["ibexa/admin-ui-assets"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
-      - name: Patch parent version for Content
-        if: github.event.repository.name == 'content'
-        run: jq '.require["ibexa/oss"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
       - name: Patch parent version for Experience
-        if: github.event.repository.name == 'experience'
         run: jq '.require["ibexa/headless"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
-      - name: Patch parent version for Commerce
-        if: github.event.repository.name == 'commerce'
-        run: jq '.require["ibexa/experience"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
 
       # The effect of this jq command is to modify the require property of the input JSON object by using values from the $release object,
       # if they exist, to update the values of the keys in the require object.


### PR DESCRIPTION
> [!CAUTION]
> - [x] Drop TMP commits before merging

| :ticket: Issue | IBX-11778 |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/gh-workflows/pull/103
- https://github.com/ibexa/gh-workflows/pull/105
- https://github.com/ibexa/commerce/pull/1891
- https://github.com/ibexa/headless/pull/286
- https://github.com/ibexa/oss/pull/285

#### Description:

Rewrote `auto_tag.yml` (Create Tag), 186 → 40 lines; for more details see ibexa/gh-workflows#105.

Specific to experience:

- The `preparation` job is gone entirely: no assets package to check, and the parent `ibexa/headless` is on Packagist, so there is nothing to wait for. Single-job workflow.


#### For QA:

The shared actions are tested in ibexa/gh-workflows#105 — see its For QA.

Test status:

- [x] :green_circle: Dry run at 4.6.31 (`real_op: false`) from this branch, exercising the ibexa/gh-workflows#105 actions via the `[TMP]` refs [Create Tag run 31009052741](https://github.com/ibexa/experience/actions/runs/31009052741) — single `action` job with no preparation, `ibexa/headless` pinned to 4.6.31, remaining requirements set from the release definition, `composer.lock` resolved, push step skipped, `ubuntu-26.04`

- [x] :green_circle: Negative dry run at bogus version 9.9.9-test1 [Create Tag run 31012128038](https://github.com/ibexa/experience/actions/runs/31012128038) — with no preparation job, the action failed at the release-definition fetch with `::error::Release definition releases/9.9.9-test1/release.json is not available in ibexa/release-maker`

#### Documentation:

No documentation required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

