### PR TITLE
[TMP] Run regression

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -23,6 +23,7 @@ jobs:
         name: "PHP 7.4/Node 20/PostgreSQL 18.0/Varnish/Redis 7.2/Multirepository"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'IBX-11919-encore-prod-on-ci'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=experience"
@@ -39,6 +40,7 @@ jobs:
         name: "PHP 8.0/Node 20/MySQL 8.0/Compatibility layer/Elastic 8"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'IBX-11919-encore-prod-on-ci'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=experience"
@@ -55,6 +57,7 @@ jobs:
         name: "PHP 8.4/Node 22/MySQL 8.4/Compatibility layer/Solr 8/Valkey latest"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'IBX-11919-encore-prod-on-ci'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=regression --suite=experience"
@@ -71,6 +74,7 @@ jobs:
         name: "Map\\Host matcher tests/PostgreSQL 14.15/Solr 7/Valkey latest"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'IBX-11919-encore-prod-on-ci'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=browser --suite=page-builder"
@@ -83,6 +87,7 @@ jobs:
         name: "Map\\URI matcher tests/MariaDB 11.4/Solr 9/Redis latest"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'IBX-11919-encore-prod-on-ci'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=browser --suite=page-builder"
@@ -95,6 +100,7 @@ jobs:
         name: "URIElement matcher tests/MariaDB 10.11/Elastic 7/Redis 5.0"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'IBX-11919-encore-prod-on-ci'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=browser --suite=page-builder"
@@ -107,6 +113,7 @@ jobs:
         name: "Compound matcher tests/MariaDB 10.11/Redis 4.0"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'IBX-11919-encore-prod-on-ci'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             test-suite: "--profile=browser --suite=page-builder"
@@ -119,6 +126,7 @@ jobs:
         name: "Site Factory tests/PHP 8.4/Node 22/PostgreSQL 18.0"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
+            ci-scripts-branch: 'IBX-11919-encore-prod-on-ci'
             project-edition: "experience"
             project-version: ${{ github.event.inputs.project-version }}
             setup: "doc/docker/base-dev.yml:doc/docker/multihost.yml:doc/docker/db-postgresql18.yml:doc/docker/selenium.yml"


### PR DESCRIPTION
| :ticket: Issue | IBX-11919 |
|----------------|-----------|

#### Description:
https://github.com/ibexa/ci-scripts/pull/143

Regression run for experience v4.6, mirroring the current state of https://github.com/ibexa/oss/pull/290: all setups keep `gh-workflows@main` unmodified and only override `ci-scripts-branch` to `IBX-11919-encore-prod-on-ci`, to validate the ci-scripts fix for building CI assets with `yarn encore prod` in isolation.
